### PR TITLE
Not participating in Google's FLoC Network

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,7 @@
 <head>
     <title>{{ .Title }}</title>
     <meta charset="utf-8">
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="{{if .IsHome}}{{ $.Site.Params.description }}{{else}}{{.Description}}{{end}}" />
 


### PR DESCRIPTION
Google has been pushing a replacement for third-party cookies that is even more harmful to user privacy. There's a way for not participating in this program. See [Opting your Website out of Google's FLoC Network](https://paramdeo.com/blog/opting-your-website-out-of-googles-floc-network).