### PR TITLE
If recent_posts is set to 0, don't include this section

### DIFF
--- a/layouts/partials/category-posts.html
+++ b/layouts/partials/category-posts.html
@@ -5,6 +5,7 @@
             {{ if isset .Site.Params "recent_posts" }}
                 {{ $recent = .Site.Params.recent_posts }}
             {{ end }}
+            {{ if gt $recent 0 }}
             <div class="pb-3">
                 <h5><span class="badge category">Recent</span></h5>
                 <ul class="list-unstyled">
@@ -16,6 +17,7 @@
                     {{ end }}
                 </ul>
             </div>
+            {{ end }}
 
             {{ range $key, $taxonomy := .Site.Taxonomies.categories.Alphabetical }}
                 <div class="pb-3">


### PR DESCRIPTION
If we have recent_posts set to 0, then don't display this section at all (it just ends up being an empty section anyway)