### PR TITLE
Added disqus comments

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,4 +2,6 @@
     <div class="pl-sm-4 ml-sm-5">
         {{ .Content }}
     </div>
+
+    {{ template "_internal/disqus.html" . }}
 {{ end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -12,4 +12,6 @@
             {{ .Content }}
         </article>
     </div>
+
+    {{ template "_internal/disqus.html" . }}
 {{ end }}


### PR DESCRIPTION
It can be good to add comments to a blog post and Hugo has inbuilt support for disqus comments.
This adds the shortcode for comments to the default and post layouts.