### PR TITLE
Added option to disable category post listings on the home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ copyright = "&copy; Copyright Year, Your Name"
   home_image = "/images/avatar.png"          # Path to header image starting from the static directory
   recent_posts = 5                           # Max amount of recent posts to show
   mainSections = ["posts", "post", "blog"]   # Main sections to include in recent posts
+  category_list = true                       # Include category posts on the home page
   [params.style]                             # CSS style overrides
     backgroundColor = "#f8f9fa"
     fontColor = "#212529"

--- a/layouts/partials/category-posts.html
+++ b/layouts/partials/category-posts.html
@@ -3,38 +3,40 @@
         <div class="col-12">
             {{ $recent := 7 }}
             {{ if isset .Site.Params "recent_posts" }}
-                {{ $recent = .Site.Params.recent_posts }}
+            {{ $recent = .Site.Params.recent_posts }}
             {{ end }}
             {{ if gt $recent 0 }}
             <div class="pb-3">
                 <h5><span class="badge category">Recent</span></h5>
                 <ul class="list-unstyled">
                     {{ range first $recent (where .Site.RegularPages "Type" "in" site.Params.mainSections) }}
-                        <li>
-                            {{ .Date.Format "Jan 2 2006" }}
-                            <a href="{{ .Permalink }}">{{ .Title }}</a>
-                        </li>
+                    <li>
+                        {{ .Date.Format "Jan 2 2006" }}
+                        <a href="{{ .Permalink }}">{{ .Title }}</a>
+                    </li>
                     {{ end }}
                 </ul>
             </div>
             {{ end }}
 
+            {{ if or (not (isset .Site.Params "category_list")) (.Site.Params.category_list)  }}
             {{ range $key, $taxonomy := .Site.Taxonomies.categories.Alphabetical }}
-                <div class="pb-3">
-                    <h5>
+            <div class="pb-3">
+                <h5>
                     <span class="badge category text-capitalize">
                         {{ .Name | humanize }}
                     </span>
-                    </h5>
-                    <ul class="list-unstyled">
-                        {{ range $taxonomy.Pages }}
-                            <li>
-                                {{ .Date.Format "Jan 2 2006" }}
-                                <a href="{{ .Permalink }}">{{ .Title }}</a>
-                            </li>
-                        {{ end }}
-                    </ul>
-                </div>
+                </h5>
+                <ul class="list-unstyled">
+                    {{ range $taxonomy.Pages }}
+                    <li>
+                        {{ .Date.Format "Jan 2 2006" }}
+                        <a href="{{ .Permalink }}">{{ .Title }}</a>
+                    </li>
+                    {{ end }}
+                </ul>
+            </div>
+            {{ end }}
             {{ end }}
         </div>
     </div>


### PR DESCRIPTION
Allow the disabling of categories from the main page.
This is only done if the "category_list" variable is declared and set to false in order not to break existing users.