### PR TITLE
Add ability to add rel="me" to social links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ copyright = "&copy; Copyright Year, Your Name"
     fa_icon = "fab fa-linkedin-in fa-1x"
     href = ""
   [[params.social]]
+    fa_icon = "fab fa-mastodon fa-1x"
+    rel_me = true                            # Add a rel="me" attr for Mastodon link verification
+    href = ""
+  [[params.social]]
     fa_icon = "fab fa-twitter fa-1x"
     href = ""
   [[params.social]]

--- a/assets/sass/override.scss
+++ b/assets/sass/override.scss
@@ -117,10 +117,6 @@ blockquote:before {
   vertical-align: -0.4em;
 }
 
-blockquote p {
-  display: inline;
-}
-
 // === Media breakpoints ===
 // 576px
 @include media-breakpoint-up(sm) {}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,7 @@
+{{ $page := . }}
+
 <head>
-    <title>{{ .Site.Title }}</title>
+    <title>{{ partial "title.html" $page }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="{{if .IsHome}}{{ $.Site.Params.description }}{{else}}{{.Description}}{{end}}" />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -43,7 +43,7 @@
             <ul id="nav-social" class="list-inline">
                 {{ range .Site.Params.social }}
                     <li class="list-inline-item mr-3">
-                        <a href="{{ .href }}" target="_blank">
+                        <a href="{{ .href }}" target="_blank"{{ if .rel_me }} rel="me"{{ end }}>
                             <i class="{{ .fa_icon }} text-muted"></i>
                         </a>
                     </li>

--- a/layouts/partials/title.html
+++ b/layouts/partials/title.html
@@ -1,0 +1,19 @@
+{{ $page := . }}
+
+{{ $pagetitle := $page.Title | markdownify | plainify | htmlUnescape }}
+{{ $result := "" }}
+{{ $sitetitle := site.Title | markdownify | plainify | htmlUnescape }}
+
+{{ if and $pagetitle $sitetitle }}
+    {{ if .IsHome }}
+        {{ $result = $pagetitle }}
+    {{ else }}
+        {{ $result = printf "%s · %s" $pagetitle $sitetitle }}
+    {{ end }}
+{{ else if $pagetitle }}
+    {{ $result = $pagetitle }}
+{{ else if $sitetitle }}
+    {{ $result = $sitetitle }}
+{{ end }}
+
+{{ return $result }}


### PR DESCRIPTION
I've added an example to the README.md of how this would be used.

Mastodon lets people verify profile links by having those links link back with this attribute set.

Background - https://microformats.org/wiki/rel-me

```html
<a href="https://mstdn.social/@aimaz" target="_blank" rel="me">
     <i class="fab fa-mastodon fa-1x text-muted"></i>
</a>
```