### PR TITLE
Add param.style.fontFamilyBase font option for body

### DIFF
--- a/assets/sass/override.scss
+++ b/assets/sass/override.scss
@@ -2,7 +2,7 @@
 $body-bg: {{ if .Param "style.backgroundColor" }}{{ .Param "style.backgroundColor"}}{{ else }}#f8f9fa{{ end }};
 $body-color: {{ if .Param "style.fontColor" }}{{ .Param "style.fontColor"}}{{ else }}#212529{{ end }};
 $home-image-border-color: {{ if .Param "style.homeImageBorderColor" }}{{ .Param "style.homeImageBorderColor"}}{{ else }}#ffffff{{ end }};
-$font-family-base: "Helvetica Neue", Arial, sans-serif;
+$font-family-base: {{ if .Param "style.fontFamilyBase"}}{{ .Param "style.fontFamilyBase"}},{{end}}"Helvetica Neue", Arial, sans-serif;
 $font-size-base: 0.95rem;
 @import "../../node_modules/bootstrap/scss/bootstrap";
 


### PR DESCRIPTION
I just extended [this PR](https://github.com/austingebauer/devise/commit/8b4bc6fb5fb28986685679a6f2267053514e87c2) for font-family-base so I could use a different font on my site. I don't think this breaks anything but I have no way to test. Love the theme btw!