### PR TITLE
Make home_image optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ copyright = "&copy; Copyright Year, Your Name"
   description = "Your meta description"      # Your meta description of the site
   header_title = "Your Name"                 # Your header title
   header_subtitle = "Your Creative Subtitle" # Your header subtitle
-  home_image = "/images/avatar.png"          # Path to header image starting from the static directory
+  home_image = "/images/avatar.png"          # Path to header image starting from the static directory (optional)
   recent_posts = 5                           # Max amount of recent posts to show
   mainSections = ["posts", "post", "blog"]   # Main sections to include in recent posts
   [params.style]                             # CSS style overrides

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
             </a>
         </div>
         {{ end }}
-        <div class="col-sm-8 col-12 text-sm-left text-center">
+        <div class="col-sm-auto col-12 text-sm-left text-center">
             <h2 class="m-0 mb-2 mt-4">
                 <a href="/" class="text-decoration-none">
                     {{ if isset .Site.Params "header_title" }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,6 @@
 <header class="container mt-sm-5 mt-4 mb-4 mt-xs-1">
     <div class="row">
+        {{ if isset .Site.Params "home_image" }}
         <div class="col-sm-4 col-12 text-sm-right text-center pt-sm-4">
             <a href="/" class="text-decoration-none">
                 <img id="home-image" class="rounded-circle"
@@ -15,6 +16,7 @@
                 />
             </a>
         </div>
+        {{ end }}
         <div class="col-sm-8 col-12 text-sm-left text-center">
             <h2 class="m-0 mb-2 mt-4">
                 <a href="/" class="text-decoration-none">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,8 +16,10 @@
                 />
             </a>
         </div>
+        <div class="col-sm-8 col-12 text-sm-left text-center">
+        {{ else }}
+        <div class="col-sm col-12 text-center">
         {{ end }}
-        <div class="col-sm col-12 text-sm-left text-center">
             <h2 class="m-0 mb-2 mt-4">
                 <a href="/" class="text-decoration-none">
                     {{ if isset .Site.Params "header_title" }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
             </a>
         </div>
         {{ end }}
-        <div class="col-sm-auto col-12 text-sm-left text-center">
+        <div class="col-sm col-12 text-sm-left text-center">
             <h2 class="m-0 mb-2 mt-4">
                 <a href="/" class="text-decoration-none">
                     {{ if isset .Site.Params "header_title" }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,7 +18,7 @@
         </div>
         <div class="col-sm-8 col-12 text-sm-left text-center">
         {{ else }}
-        <div class="col-sm col-12 text-center">
+        <div class="col-12 text-center">
         {{ end }}
             <h2 class="m-0 mb-2 mt-4">
                 <a href="/" class="text-decoration-none">


### PR DESCRIPTION
This pull request makes `home_image` optional as I wanted to use the theme without the large header image. By omitting the config key, the image and its placeholder disappears, giving more space to the header and link section. 

Tested on latest Firefox and Chromium. Feedback welcome as I am in no way a frontend guy.