### PR TITLE
add support for codecolor customization and w3 compliant favicon paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ copyright = "&copy; Copyright Year, Your Name"
     homeImageBorderColor = "#ffffff"
     fontFamilyBase = "Helvetica Neue"        # First-choice font
     fontColor = "#212529"
-    fontFamilyBase = "Helvetica Neue"
     codeColor = "#e83e8c"
   [[params.social]]
     fa_icon = "fab fa-github fa-1x"          # Font Awesome icon class

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ copyright = "&copy; Copyright Year, Your Name"
   header_title = "Your Name"                 # Your header title
   header_subtitle = "Your Creative Subtitle" # Your header subtitle
   home_image = "/images/avatar.png"          # Path to header image starting from the static directory (optional)
+  favicon = "/favicon.ico"                   # Path to favicon image starting from static. Defaults to "./favicon.ico"
+  favicon_type = "x-icon"                    # Image extension. Defaults to x-icon
   recent_posts = 5                           # Max amount of recent posts to show
   mainSections = ["posts", "post", "blog"]   # Main sections to include in recent posts
   [params.style]                             # CSS style overrides
@@ -99,6 +101,8 @@ copyright = "&copy; Copyright Year, Your Name"
     homeImageBorderColor = "#ffffff"
     fontFamilyBase = "Helvetica Neue"        # First-choice font
     fontColor = "#212529"
+    fontFamilyBase = "Helvetica Neue"
+    codeColor = "#e83e8c"
   [[params.social]]
     fa_icon = "fab fa-github fa-1x"          # Font Awesome icon class
     href = "http://github.com/youruser"      # Link to associate with icon (http://, https://, mailto:)

--- a/assets/sass/override.scss
+++ b/assets/sass/override.scss
@@ -4,6 +4,7 @@ $body-color: {{ if .Param "style.fontColor" }}{{ .Param "style.fontColor"}}{{ el
 $home-image-border-color: {{ if .Param "style.homeImageBorderColor" }}{{ .Param "style.homeImageBorderColor"}}{{ else }}#ffffff{{ end }};
 $font-family-base: {{ if .Param "style.fontFamilyBase"}}{{ .Param "style.fontFamilyBase"}},{{end}}"Helvetica Neue", Arial, sans-serif;
 $font-size-base: 0.95rem;
+$code-color: {{ if .Param "style.codeColor" }}{{ .Param "style.codeColor"}}{{ else }}"inherit"{{ end }};
 @import "../../node_modules/bootstrap/scss/bootstrap";
 
 // === Import Font Awesome ===

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,6 +4,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="{{if .IsHome}}{{ $.Site.Params.description }}{{else}}{{.Description}}{{end}}" />
 
+    {{/* Adds favicon specification to config.toml */}}
+    <link rel="icon" type= {{
+        if $.Site.Params.favicon_type }}{{ path.Join "image/" $.Site.Params.favicon_type }}{{ else }}{{ "image/x-icon" }}{{end
+        }} href= {{
+        if $.Site.Params.favicon }}{{ $.Site.Params.favicon }}{{ else }}{{ "/favicon.ico" }}{{end
+        }}>
+
     {{/* Adds complete override capability */}}
     {{ $overrideTemplate := resources.Get "sass/override.scss" }}
     {{ $override := $overrideTemplate | resources.ExecuteAsTemplate "css/theme.scss" . | toCSS | minify }}


### PR DESCRIPTION
w3 favicon compliance is documented [here](https://www.w3.org/2005/10/howto-favicon)

this isn't super necessary but it removes the need to make a partial layout for the html tag i think