### PR TITLE
| safeURL in .Site.Params.social

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,7 +47,7 @@
             <ul id="nav-social" class="list-inline">
                 {{ range .Site.Params.social }}
                     <li class="list-inline-item mr-3">
-                        <a href="{{ .href }}" target="_blank">
+                        <a href="{{ .href | safeURL }}" target="_blank">
                             <i class="{{ .fa_icon }} text-muted"></i>
                         </a>
                     </li>


### PR DESCRIPTION
Hi! I was trying to use href="tel:..." in social links but hugo's URL filter was masking it. I hope you consider this improvement. 